### PR TITLE
Modify meta tags for each page

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -59,4 +59,7 @@ const { title, description, image = "/burger-card.png" } = Astro.props;
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={new URL(image, Astro.url)} />
-<meta property="twitter:image:alt" content="Serving up tasty bytes since 2014" />
+<meta
+  property="twitter:image:alt"
+  content="Serving up tasty bytes since 2014"
+/>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -17,7 +17,7 @@ const { title, description, pubDate, updatedDate, heroImage, tags } =
 
 <html lang="en">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead title={title} description={description} image={heroImage} />
     <style>
       main {
         width: calc(100% - 2em);

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -3,19 +3,21 @@ import BaseHead from "../../components/BaseHead.astro";
 import Header from "../../components/Header.astro";
 import Cards from "../../components/Cards.astro";
 import Footer from "../../components/Footer.astro";
-import { SITE_TITLE, SITE_DESCRIPTION } from "../../consts";
 import { getCollection } from "astro:content";
 
 const isDev = import.meta.env.MODE === "development";
-const posts = (await getCollection("blog"))
-  .filter((p) => isDev || (!isDev && p.data.published))
-  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+const posts = (
+  await getCollection("blog", (p) => isDev || (!isDev && p.data.published))
+).sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+    <BaseHead
+      title={"Nick's blog"}
+      description={`Read Nick's thoughts about web development, JavaScript, and more!`}
+    />
   </head>
   <body>
     <Header />

--- a/src/pages/resume/index.astro
+++ b/src/pages/resume/index.astro
@@ -9,7 +9,10 @@ import resume from "../../../resume.json";
 <!doctype html>
 <html lang="en">
   <head>
-    <BaseHead description="Nicholas Patti resume" title="Résumé" />
+    <BaseHead
+      title="Nick Patti's Resume"
+      description="A concise list of Nick's software development experience"
+    />
     <style>
       p {
         margin: 0;

--- a/src/pages/resume/index.astro
+++ b/src/pages/resume/index.astro
@@ -10,7 +10,7 @@ import resume from "../../../resume.json";
 <html lang="en">
   <head>
     <BaseHead
-      title="Nick Patti's Resume"
+      title="Nick Patti's Résumé"
       description="A concise list of Nick's software development experience"
     />
     <style>

--- a/src/pages/tags/[id].astro
+++ b/src/pages/tags/[id].astro
@@ -36,7 +36,7 @@ const title = `Posts tagged "${tagName}"`;
 const description =
   posts.length > 0
     ? `Nick has written ${posts.length} posts about this topic, which you can find here!`
-    : `Nick hasn't written any posts about this topic. Come back later!`;
+    : `Nick hasn't written any posts about this topic yet. Come back later!`;
 ---
 
 <!doctype html>
@@ -48,7 +48,7 @@ const description =
     <Header />
     <main id="content-start">
       <h1>Posts tagged <code>{tagName}</code></h1>
-      <Cards {posts} />
+      {posts.length > 0 ? <Cards {posts} /> : <p>{description}</p>}
     </main>
     <Footer />
   </body>

--- a/src/pages/tags/[id].astro
+++ b/src/pages/tags/[id].astro
@@ -32,17 +32,22 @@ const filteredPosts = await getCollection("blog", (p: Blog) => {
 const posts = filteredPosts.sort(
   (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
 );
+const title = `Posts tagged "${tagName}"`;
+const description =
+  posts.length > 0
+    ? `Nick has written ${posts.length} posts about this topic, which you can find here!`
+    : `Nick hasn't written any posts about this topic. Come back later!`;
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+    <BaseHead {title} {description} />
   </head>
   <body>
     <Header />
     <main id="content-start">
-      <h1>{tagName}</h1>
+      <h1>Posts tagged <code>{tagName}</code></h1>
       <Cards {posts} />
     </main>
     <Footer />

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -8,7 +8,6 @@ import { getCollection } from "astro:content";
 
 const tags = await getCollection("tags")
 const description = `Nick has written about ${tags.length} topics. Check them out here!`
-console.log(description)
 ---
 
 <!doctype html>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -4,16 +4,17 @@ import '../../styles/tags.css'
 import BaseHead from "../../components/BaseHead.astro";
 import Header from "../../components/Header.astro";
 import Footer from "../../components/Footer.astro";
-import { SITE_TITLE, SITE_DESCRIPTION } from "../../consts";
 import { getCollection } from "astro:content";
 
 const tags = await getCollection("tags")
+const description = `Nick has written about ${tags.length} topics. Check them out here!`
+console.log(description)
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+    <BaseHead title={"Tag list"} {description} />
   </head>
   <body>
     <Header />


### PR DESCRIPTION
When I link pages to other places, the title, description, and image of the site is the same. This makes it difficult to see what page I'm actually linking when I post links on social media.

The links that should have the correct tags are:
- `src/pages/index.astro` The home page
- `src/pages/blog/index.astro` The blog index page
- `src/pages/blog/[...slug].astro` An individual blog page
- `src/pages/tags/index.astro` The tags index page
- `src/pages/tags/[id].astro` An individual tag page
- `src/pages/resume/index.astro` The resume page
