### PR TITLE
Modify 404 message

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,7 +1,6 @@
 ---
 import BaseHead from "../components/BaseHead.astro";
 import Header from "../components/Header.astro";
-const path = new URL(Astro.request.url).pathname;
 ---
 
 <!doctype html>
@@ -9,7 +8,7 @@ const path = new URL(Astro.request.url).pathname;
   <head>
     <BaseHead
       title={"404 error"}
-      description={`404 error - couldn't find page ${path}`}
+      description={`404 error - couldn't find the page`}
     />
     <style>
       main {
@@ -29,7 +28,7 @@ const path = new URL(Astro.request.url).pathname;
     <main>
       <h3>Whoops!</h3>
       <code>404 Not Found</code>
-      <p>Couldn't find page: <code>{path}</code></p>
+      <p>The page you're looking for is not here ┐(´ー｀)┌</p>
     </main>
   </body>
 </html>


### PR DESCRIPTION
Since I'm not running my pages on a vite server when I deploy my site, the URL that is read when I go to a 404 page is not the one I expect.

This just removes the pathname from the 404 page since I don't really need it.