### PR TITLE
Info, warning, and danger boxes in blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ Blog images
 - place them in the `src/assets/blog/<blog-name>` directory
 - Images here will be processed by Astro
 
+### Info, Warning, and Danger sections
+
+```md
+<div class="[info|warning|danger]">
+
+Here's your text
+
+Don't forget the spaces in the front and back. **Formatting works, too!**
+
+</div>
+```
+
 ## Adding new tags
 
 1. Create a new YAML file (this filename is pretty much the slug of the tag)

--- a/src/content/blog/info-boxes-test.md
+++ b/src/content/blog/info-boxes-test.md
@@ -6,19 +6,23 @@ heroImage: ""
 published: false
 ---
 
-This is a box with some stuff in it.
+Here are some boxes that I think would be useful for my site.
 
 <div class="info">
 
-Now, this is an informational thingy. Pro tip! This makes the information section look pretty good! This will be rendered as just a span inside this div.
+Pro-tip!
 
-Take a look at this and DONT MESS THIS UP
+You can make these boxes with text look pretty good by just using the page, but perhaps I want to just do something simpler?
 
 </div>
 
+I've been busy making these boxes look real good, but are they good enough?
+
 <div class="warning">
 
-This right here is a warning.
+This right here is a warning. You should be careful when dealing with this stuff.
+
+**Does this work**
 
 </div>
 
@@ -27,3 +31,5 @@ This right here is a warning.
 Look out! There's a problem here!
 
 </div>
+
+This concludes the test. Thanks for reading!

--- a/src/content/blog/info-boxes-test.md
+++ b/src/content/blog/info-boxes-test.md
@@ -1,0 +1,29 @@
+---
+title: "Info, Warning, and Danger boxes"
+description: "This is a test"
+pubDate: "2024-05-16PST"
+heroImage: ""
+published: false
+---
+
+This is a box with some stuff in it.
+
+<div class="info">
+
+Now, this is an informational thingy. Pro tip! This makes the information section look pretty good! This will be rendered as just a span inside this div.
+
+Take a look at this and DONT MESS THIS UP
+
+</div>
+
+<div class="warning">
+
+This right here is a warning.
+
+</div>
+
+<div class="danger">
+
+Look out! There's a problem here!
+
+</div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -62,18 +62,18 @@ main {
 }
 
 .info {
-  --background-color: var(--blue2);
-  --text-color: var(--blue1);
+  --blue1rgb: 69, 133, 136;
+  --background-color: var(--blue1rgb);
 }
 
 .warning {
-  --background-color: var(--yellow2);
-  --text-color: var(--yellow1);
+  --yellow1rgb: 215, 153, 33;
+  --background-color: var(--yellow1rgb);
 }
 
 .danger {
-  --background-color: var(--red2);
-  --text-color: var(--red1);
+  --red1rgb: 204, 36, 29;
+  --background-color: var(--red1rgb);
 }
 
 .info,
@@ -82,9 +82,8 @@ main {
   margin: 1.5em 0;
   padding: 0 1em;
   border-radius: 8px;
-  border: solid 3px var(--text-color);
-  background: var(--background-color);
-  color: var(--bg0);
+  border: 2px solid rgb(var(--background-color));
+  background: rgba(var(--background-color), 0.33);
 
   p:last-child {
     margin-bottom: 1em;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -62,18 +62,18 @@ main {
 }
 
 .info {
-  --blue1rgb: 69, 133, 136;
-  --background-color: var(--blue1rgb);
+  /* blue1 in rgb */
+  --background-color: 69, 133, 136;
 }
 
 .warning {
-  --yellow1rgb: 215, 153, 33;
-  --background-color: var(--yellow1rgb);
+  /* yellow1 in rgb */
+  --background-color: 215, 153, 33;
 }
 
 .danger {
-  --red1rgb: 204, 36, 29;
-  --background-color: var(--red1rgb);
+  /* red1 in rgb */
+  --background-color: 204, 36, 29;
 }
 
 .info,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -61,6 +61,36 @@ main {
   padding: 3em 1em;
 }
 
+.info {
+  --background-color: var(--blue2);
+  --text-color: var(--blue1);
+}
+
+.warning {
+  --background-color: var(--yellow2);
+  --text-color: var(--yellow1);
+}
+
+.danger {
+  --background-color: var(--red2);
+  --text-color: var(--red1);
+}
+
+.info,
+.warning,
+.danger {
+  margin: 1.5em 0;
+  padding: 0 1em;
+  border-radius: 8px;
+  border: solid 3px var(--text-color);
+  background: var(--background-color);
+  color: var(--bg0);
+
+  p:last-child {
+    margin-bottom: 1em;
+  }
+}
+
 h1,
 h2,
 h3,
@@ -72,9 +102,8 @@ h6 {
   line-height: 1.2;
 }
 
-
 h1 {
-  font-size: 3em;  
+  font-size: 3em;
 }
 
 h1 a {
@@ -94,14 +123,14 @@ h3 {
 }
 
 h3 a {
-  --link-icon-size: 1.6rem; 
+  --link-icon-size: 1.6rem;
 }
 
 h4 {
   font-size: 1.563em;
 }
 
-h4 a {  
+h4 a {
   --link-icon-size: 1.4rem;
 }
 
@@ -234,12 +263,12 @@ h3:hover path,
 h4:hover path,
 h5:hover path,
 h6:hover path {
-  opacity: 1.0;
+  opacity: 1;
 }
 
 a.link-icon-container:hover path,
 a.link-icon-container:focus path {
-  opacity: 1.0;
+  opacity: 1;
 }
 
 .sr-only {
@@ -277,4 +306,3 @@ a.link-icon-container:focus path {
   color: var(--fg0);
   text-decoration: none;
 }
-


### PR DESCRIPTION
Add styles for different colored boxes into markdown files like this:

```md
<div class="info">

Pro-tip!

You can make these boxes with text look pretty good by just using the page, but perhaps I want to just do something simpler?

</div>
```

<details>
<summary>Screenshots</summary>

Desktop
![boxes-desktop](https://github.com/NicksPatties/portfolio-site/assets/3261001/5eb68099-823a-468a-8698-b93bb5d8c4b0)
![boxes-desktop-light](https://github.com/NicksPatties/portfolio-site/assets/3261001/8759c449-c0b8-47eb-88e3-fdaf70c0619e)

Mobile
![boxes-mobile](https://github.com/NicksPatties/portfolio-site/assets/3261001/77c6681b-a6af-4a4a-bf20-63d883e48b07)
![boxes-mobile-light](https://github.com/NicksPatties/portfolio-site/assets/3261001/931e06b4-32b1-4cad-a60c-9a3b357e2422)


</details>