### PR TITLE
Validate HTML in TagsList

### DIFF
--- a/src/components/TagsList.astro
+++ b/src/components/TagsList.astro
@@ -27,7 +27,11 @@ const center: boolean = Astro.props.links || false;
     project && (
       <li>
         {links ? (
-          <a class="tag-pill project" href={"/projects/" + project.slug}>
+          <a
+            class="tag-pill project"
+            href={"/projects/" + project.slug}
+            aria-label={project.data.name + " project"}
+          >
             {project.data.name}
           </a>
         ) : (
@@ -41,7 +45,11 @@ const center: boolean = Astro.props.links || false;
       tags.map(async (g: Tag) => {
         const tag: Tag = await getEntry("tags", g.id);
         const inner = links ? (
-          <a class="tag-pill" href={"/tags/" + tag.id}>
+          <a
+            class="tag-pill"
+            href={"/tags/" + tag.id}
+            aria-label={tag.data.name + " tag"}
+          >
             {tag.data.name}
           </a>
         ) : (

--- a/src/components/TagsList.astro
+++ b/src/components/TagsList.astro
@@ -25,32 +25,29 @@ const center: boolean = Astro.props.links || false;
 <ul class={center ? "tags-list center" : "tags-list"}>
   {
     project && (
-      <>
-        <span class="sr-only">Part of the project</span>
+      <li>
         {links ? (
           <a class="tag-pill project" href={"/projects/" + project.slug}>
-            <li>{project.data.name}</li>
+            {project.data.name}
           </a>
         ) : (
-          <li class="tag-pill project">{project.data.name}</li>
+          <span class="tag-pill project">{project.data.name}</span>
         )}
-      </>
+      </li>
     )
   }
-  {tags && <span class="sr-only">Contains the tags</span>}
   {
     tags &&
       tags.map(async (g: Tag) => {
         const tag: Tag = await getEntry("tags", g.id);
-        return links ? (
+        const inner = links ? (
           <a class="tag-pill" href={"/tags/" + tag.id}>
-            <li aria-label={tag.data.name}>{tag.data.name}</li>
+            {tag.data.name}
           </a>
         ) : (
-          <li class="tag-pill" aria-label={tag.data.name}>
-            {tag.data.name}
-          </li>
+          <span class="tag-pill">{tag.data.name}</span>
         );
+        return <li>{inner}</li>;
       })
   }
 </ul>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,9 +1,9 @@
 ---
 import { type CollectionEntry, getEntry } from "astro:content";
-import BaseHead from "../components/BaseHead.astro";
-import Header from "../components/Header.astro";
-import Footer from "../components/Footer.astro";
-import FormattedDate from "../components/FormattedDate.astro";
+import BaseHead from "@components/BaseHead.astro";
+import Header from "@components/Header.astro";
+import Footer from "@components/Footer.astro";
+import FormattedDate from "@components/FormattedDate.astro";
 import TagsList from "@components/TagsList.astro";
 
 type Blog = CollectionEntry<"blog">;

--- a/src/styles/card.css
+++ b/src/styles/card.css
@@ -24,7 +24,7 @@
   margin: 0;
 }
 
-.card .tags-list li {
+.card .tags-list .tag-pill {
   transition: all var(--animation);
 }
 
@@ -34,13 +34,13 @@
 
 .card:hover .title,
 .card:hover .date,
-.card:hover .tags-list li {
+.card:hover .tags-list .tag-pill {
   color: var(--green2);
   border-color: var(--green2);
 }
 
-.card:hover .tags-list li.tag-pill.project,
-.card:focus .tags-list li.tag-pill.project {
+.card:hover .tags-list .tag-pill.project,
+.card:focus .tags-list .tag-pill.project {
   background-color: var(--green2);
   border-color: var(--green2);
   color: var(--bg);
@@ -48,7 +48,7 @@
 
 .card:focus .title,
 .card:focus .date,
-.card:focus .tags-list li {
+.card:focus .tags-list .tag-pill {
   border-color: var(--green2);
   color: var(--green2);
 }

--- a/src/styles/tags.css
+++ b/src/styles/tags.css
@@ -12,6 +12,10 @@
   justify-content: center;
 }
 
+.tags-list li {
+  margin-right: 0.5rem;
+}
+
 .tag-pill {
   display: inline-block;
   text-decoration: none;
@@ -22,7 +26,6 @@
   border-width: 2px;
   border-style: solid;
   border-color: var(--orange2);
-  margin-right: 0.5rem;
   padding: 0 0.5rem;
   border-radius: 12px;
 }


### PR DESCRIPTION
[The W3C HTML validator]() returned some errors, so I fixed them.

<details>
<summary>Won't fix (yet?)</summary>

I ignored these errors in my fixes since they didn't seem to be doing anything detrimental. Also, I was gonna ask a question about [the function that made the responsible code](https://github.com/withastro/astro/blob/8ce66f2ef7328546d823f1076f9bab4217a6be7d/packages/markdown/remark/src/rehype-prism.ts#L12), but I haven't yet. Here's the error in question below. Note that this repeats for every code block on a blog page.

### Error: Attribute is:raw not allowed on element [code](https://html.spec.whatwg.org/multipage/#the-code-element) at this point.

From line 27, column 49; to line 27, column 86

`ge="html"><code is:raw="" class="language-html"><span `

Attributes for element [code](https://html.spec.whatwg.org/multipage/#the-code-element):
[Global attributes](https://html.spec.whatwg.org/multipage/#global-attributes)
</details>