### PR TITLE
74 fix nesting of list items in table of contents

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,6 +1,26 @@
 ---
 import type { MarkdownHeading } from "astro";
+import  TableOfContentsHeading  from "@components/TableOfContentsHeading.astro";
 const { headings } = Astro.props;
+
+function buildToc(headings) {
+  const toc = [];
+  // map of int depth and myHeading type
+  const parentHeadings = new Map();
+  headings.forEach((h) => {
+    const myHeading = { ...h, subheadings: [] };
+    parentHeadings.set(myHeading.depth, myHeading);
+    // Change 2 to 1 if your markdown includes your <h1>
+    if (myHeading.depth === 1) {
+      toc.push(myHeading);
+    } else {
+      parentHeadings.get(myHeading.depth - 1).subheadings.push(myHeading);
+    }
+  });
+  return toc;
+}
+
+const toc = buildToc(headings)
 ---
 
 <style>
@@ -25,32 +45,7 @@ const { headings } = Astro.props;
 
   input[type="checkbox"]:checked + nav {
     display: block;
-  }
-
-  li.d2 {
-    margin-inline-start: calc(var(--list-spacing) * 1);
-    list-style-type: circle;
-  }
-
-  li.d3 {
-    margin-inline-start: calc(var(--list-spacing) * 2);
-    list-style-type: square;
-  }
-
-  li.d4 {
-    margin-inline-start: calc(var(--list-spacing) * 3);
-    list-style-type: disc;
-  }
-
-  li.d5 {
-    margin-inline-start: calc(var(--list-spacing) * 4);
-    list-style-type: circle;
-  }
-
-  li.d6 {
-    margin-inline-start: calc(var(--list-spacing) * 5);
-    list-style-type: square;
-  }
+  }  
 </style>
 <div class="toc">
   <label for="toc-toggle">
@@ -59,17 +54,7 @@ const { headings } = Astro.props;
   <input id="toc-toggle" type="checkbox" />
   <nav>
     <ul>
-      {
-        headings.map((h: MarkdownHeading) => {
-          const className = `d${h.depth}`;
-          const href = `#${h.slug}`;
-          return (
-            <li class={className}>
-              <a href={href}>{h.text}</a>
-            </li>
-          );
-        })
-      }
+      {toc.map((heading) => <TableOfContentsHeading myHeading={heading} />)}
     </ul>
   </nav>
 </div>

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,16 +1,13 @@
 ---
-import type { MarkdownHeading } from "astro";
-import  TableOfContentsHeading  from "@components/TableOfContentsHeading.astro";
+import TableOfContentsHeading from "@components/TableOfContentsHeading.astro";
 const { headings } = Astro.props;
 
 function buildToc(headings) {
   const toc = [];
-  // map of int depth and myHeading type
   const parentHeadings = new Map();
   headings.forEach((h) => {
     const myHeading = { ...h, subheadings: [] };
     parentHeadings.set(myHeading.depth, myHeading);
-    // Change 2 to 1 if your markdown includes your <h1>
     if (myHeading.depth === 1) {
       toc.push(myHeading);
     } else {
@@ -54,7 +51,9 @@ const toc = buildToc(headings)
   <input id="toc-toggle" type="checkbox" />
   <nav>
     <ul>
-      {toc.map((heading) => <TableOfContentsHeading myHeading={heading} />)}
+      {
+        toc.map((heading) => <TableOfContentsHeading myHeading={heading} />)
+      }
     </ul>
   </nav>
 </div>

--- a/src/components/TableOfContentsHeading.astro
+++ b/src/components/TableOfContentsHeading.astro
@@ -1,0 +1,19 @@
+---
+const { myHeading } = Astro.props;
+---
+
+<li>
+  <a href={'#' + myHeading.slug}>
+    {myHeading.text}
+  </a>
+  {
+    myHeading.subheadings.length > 0 && (
+      <ul>
+        {myHeading.subheadings.map((subheading) => (
+          <Astro.self myHeading={subheading} />
+        ))}
+      </ul>
+    )
+  }
+</li>
+


### PR DESCRIPTION
Fixes the semantic layout of the table of contents. Instead of moving list items with CSS, nest them in their corresponding unordered list. The change is most evident in text based web browsers.

**before**
![table of contents with only one level with w3m](https://github.com/user-attachments/assets/e17e214f-d992-4d0e-8f3f-ba045741370b)

**after**
![table of contents with nesting in w3m](https://github.com/user-attachments/assets/4bdf0ed7-58d4-4ed3-b05d-f2fd11917ac1)
