### PR TITLE
Fix date off-by-one error

### DIFF
--- a/src/content/blog/adding-tags.md
+++ b/src/content/blog/adding-tags.md
@@ -1,7 +1,7 @@
 ---
 title: "Adding tags"
 description: "The description for me adding tags"
-pubDate: "2024-04-18PDT" # Don't forget the timezone code at the end!
+pubDate: "2024-04-18PST" # Don't forget the timezone code at the end!
 published: false
 project: "portfolio-site"
 tags:

--- a/src/content/blog/building-the-site-part-2.md
+++ b/src/content/blog/building-the-site-part-2.md
@@ -1,7 +1,7 @@
 ---
 title: "Building the site: Part 2"
 description: "I share my thoughts on good blog design, and how I modified the default Astro blog template to improve my reading experience."
-pubDate: "2024-05-07PDT"
+pubDate: "2024-05-07PST"
 published: true
 heroImage: "/blog/building-the-site-part-2/cover.jpg"
 project: "portfolio-site"

--- a/src/content/blog/building-the-site.md
+++ b/src/content/blog/building-the-site.md
@@ -2,7 +2,7 @@
 title: "Building the site"
 description: "I share how I enhanced my site from a template to the site you see now!"
 # watch out date is in standard time shows up wrong fix it
-pubDate: "2024-04-29PDT"
+pubDate: "2024-04-29PST"
 heroImage: "/building-the-site-cover-kevin-ku.jpg"
 published: true
 project: "portfolio-site"

--- a/src/content/blog/migrating-from-github-pages-to-caddy.md
+++ b/src/content/blog/migrating-from-github-pages-to-caddy.md
@@ -1,8 +1,8 @@
 ---
 title: "Attack of the Macs?! Migrating from GitHub Pages to Caddy"
 description: "GitHub Pages served me well, but I want to actually see what's going on with my site."
-startDate: "2024-08-28PDT"
-pubDate: "2024-08-28PDT"
+startDate: "2024-08-28PST"
+pubDate: "2024-08-28PST"
 published: true # Set to true when you're ready
 heroImage: "/blog/migrating-from-github-pages-to-caddy/cover.png"
 project: "portfolio-site"

--- a/src/content/blog/no-more-powerpoint.md
+++ b/src/content/blog/no-more-powerpoint.md
@@ -1,8 +1,8 @@
 ---
 title: "No More PowerPoint: Presentations in the terminal?!"
 description: "Presentation software is clunky to me, so can I improve my process by using the terminal?"
-startDate: "2024-09-12PDT"
-pubDate: "2024-09-12PDT" # YYYY-MM-DDPDT
+startDate: "2024-09-12PST"
+pubDate: "2024-09-12PST" # YYYY-MM-DDPDT
 published: true # Set to true when you're ready
 heroImage: "/blog/no-more-powerpoint/cover.png"
 tags:

--- a/src/content/blog/reading-the-news-with-newsboat-and-lynx.md
+++ b/src/content/blog/reading-the-news-with-newsboat-and-lynx.md
@@ -2,8 +2,8 @@
 title: "Reading the news with Newsboat and Lynx"
 description: "I find a less annoying way to read the news using command line tools and RSS."
 heroImage: "/blog/reading-the-news-with-newsboat-and-lynx/pexels-ivan-samkov-4238516.jpg"
-startDate: "2024-06-21PDT"
-pubDate: "2024-06-30PDT"
+startDate: "2024-06-21PST"
+pubDate: "2024-06-30PST"
 published: true
 tags:
   - "cli"

--- a/src/content/blog/scraping-limp-bizkit-setlist-data-part-2.md
+++ b/src/content/blog/scraping-limp-bizkit-setlist-data-part-2.md
@@ -1,8 +1,8 @@
 ---
 title: "Scrapin' the Bizkit Part 2: Re-Arranged"
 description: "My first scraper with Playwright was pretty good, but we can do better with bun and SQLite!"
-startDate: "2024-07-25PDT"
-pubDate: "2024-08-02PDT" # Don't forget the timezone code at the end!
+startDate: "2024-07-25PST"
+pubDate: "2024-08-02PST" # Don't forget the timezone code at the end!
 heroImage: "/blog/scraping-limp-bizkit-setlist-data-part-2/cover.png"
 published: true
 tags:

--- a/src/content/blog/setting-up-c-sharp-on-ubuntu.md
+++ b/src/content/blog/setting-up-c-sharp-on-ubuntu.md
@@ -1,7 +1,7 @@
 ---
 title: "Minimal C# Setup on Ubuntu"
 description: "I find the easiest way to set up .NET for writing C# code in Helix on Ubuntu"
-pubDate: "2024-06-03PDT"
+pubDate: "2024-06-03PST"
 heroImage: "/blog/setting-up-c-sharp-on-ubuntu/cover.png"
 published: true
 tags:

--- a/src/content/blog/sweet-sprint-01.md
+++ b/src/content/blog/sweet-sprint-01.md
@@ -1,8 +1,8 @@
 ---
 title: "Sweet Sprint Update 01"
 description: "Time for a do-over. I rewrite argument and file handling for typing exercise selection."
-startDate: "2024-10-02PDT"
-pubDate: "2024-10-02PDT"
+startDate: "2024-10-02PST"
+pubDate: "2024-10-02PST"
 published: true
 heroImage: "/blog/sweet-sprint-01/cover.png"
 project: "sweet"

--- a/src/content/blog/sweet-update-02.md
+++ b/src/content/blog/sweet-update-02.md
@@ -1,8 +1,8 @@
 ---
 title: "Sweet Update 02"
 description: "New features have been added to sweet's results screen, including a words per minute graph!"
-startDate: "2024-10-29PDT"
-pubDate: "2024-10-29PDT"
+startDate: "2024-10-29PST"
+pubDate: "2024-10-29PST"
 published: true
 heroImage: "/blog/sweet-update-02/cover.png"
 project: "sweet"

--- a/src/content/blog/sweet-update-03.md
+++ b/src/content/blog/sweet-update-03.md
@@ -1,8 +1,8 @@
 ---
 title: "Sweet Update 03"
 description: "View your performance over time with `sweet stats`!"
-startDate: "2024-12-19PDT"
-pubDate: "2024-12-19PDT"
+startDate: "2024-12-19PST"
+pubDate: "2024-12-19PST"
 published: true
 heroImage: "/blog/sweet-update-03/cover.png"
 project: "sweet"

--- a/src/content/blog/using-fabric-to-learn-fast.md
+++ b/src/content/blog/using-fabric-to-learn-fast.md
@@ -1,8 +1,8 @@
 ---
 title: "Using Fabric to Learn Fast"
 description: "How much time can I save using fabric, a CLI powered by AI, to gather info from YouTube videos?"
-startDate: "2024-06-04PDT" # No option for this yet
-pubDate: "2024-06-14PDT"
+startDate: "2024-06-04PST" # No option for this yet
+pubDate: "2024-06-14PST"
 heroImage: "/blog/using-fabric-to-learn-fast/guillaume-meurice-cover.png"
 published: true
 tags:

--- a/src/content/blog/using-playwright-to-scrape-limp-bizkit-setlist-data.md
+++ b/src/content/blog/using-playwright-to-scrape-limp-bizkit-setlist-data.md
@@ -1,8 +1,8 @@
 ---
 title: "Planning the ultimate Limp Bizkit experience with Playwright"
 description: "How can my friend and I get on stage to perform guitar and bass with Limp Bizkit? The answer lies in the data."
-startDate: "2024-06-06PDT"
-pubDate: "2024-07-08PDT" # Don't forget the timezone code at the end!
+startDate: "2024-06-06PST"
+pubDate: "2024-07-08PST" # Don't forget the timezone code at the end!
 heroImage: "/blog/using-playwright-to-scrape-limp-bizkit-setlist-data/cover.png"
 published: true
 tags:

--- a/src/content/blog/welcome-to-the-new-site.md
+++ b/src/content/blog/welcome-to-the-new-site.md
@@ -2,7 +2,7 @@
 title: "Welcome to the new site!"
 description: "An introduciton to my new portfolio, and the technology that powers it."
 # watch out date is in standard time shows up wrong fix it
-pubDate: "2024-04-18PDT"
+pubDate: "2024-04-18PST"
 # optional, assumes image is in the `public` folder
 heroImage: "/welcome-to-the-new-site-cover-pexels-pixabay.jpg"
 published: true


### PR DESCRIPTION
Changed the dates from PDT to PST.

This should prevent dates from displaying a date one day before the actual publish date.
